### PR TITLE
Reference the build-and-publish job in the needs array of call-e2e-test job. This enables the usage of build-and-publish outputs

### DIFF
--- a/.github/workflows/publish-and-deploy.yaml
+++ b/.github/workflows/publish-and-deploy.yaml
@@ -165,7 +165,7 @@ jobs:
           argocd app wait "$APP_NAME" --health --sync --timeout 300
 
   call-e2e-test:
-    needs: deploy
+    needs: [deploy, build-and-publish]
     uses: ./.github/workflows/test-app-with-n8n.yaml # Using n8n self-hosted agent
     with:
       build-image-tag: ${{ needs.build-and-publish.outputs.image_tag }}


### PR DESCRIPTION
Added reference to build-and-publish job in needs array of call-e2e-test 